### PR TITLE
Update start-vnc-session.sh

### DIFF
--- a/dockerfiles/start-vnc-session.sh
+++ b/dockerfiles/start-vnc-session.sh
@@ -3,4 +3,4 @@ sudo rm -f /tmp/.X1-lock
 sudo nohup X ${DISPLAY} -config /etc/X11/xorg.conf > /dev/null 2>&1 &
 nohup startxfce4 > /dev/null 2>&1 &
 nohup x11vnc -localhost -display ${DISPLAY} -N -forever -shared -bg > /dev/null 2>&1
-nohup /opt/novnc/utils/launch.sh --web /opt/novnc --vnc localhost:5901 --listen 6080 > /dev/null 2>&1 &
+nohup /opt/novnc/utils/novnc_proxy --web /opt/novnc --vnc localhost:5901 --listen 6080 > /dev/null 2>&1 &


### PR DESCRIPTION
Following up on https://github.com/novnc/noVNC/pull/1449, we need to update our infrastructure to use `novnc_proxy` as the launcher.

cc @mfussi66